### PR TITLE
Update  to v5.6.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  mesters_org: installers
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  mesters_org: installers
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,21 +2,16 @@
 # NOTE: the test step triggers antivirus stuff.  Let IT know that you're building a new pyinstaller release,
 #    and that they should watch for hello.exe triggering alerts.  Windows jobs in particular will fail with
 #    what looks like a permission error.
-{% set version = "4.8" %}
-{% set sha256 = "7ae868bbcc502832a2c802c84a1dbb9f48b44445c50144c29bfcd7b760140e13" %}
+{% set version = "5.6.2" %}
+{% set sha256 = "865025b6809d777bb0f66d8f8ab50cc97dc3dbe0ff09a1ef1f2fd646432714fc" %}
 
 package:
-  name: {{ name.lower() }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: pyinstaller-{{ version }}.tar.gz
-  url: https://files.pythonhosted.org/packages/7f/6b/688fceb8f1fafeb028de72ad47c5b1377be9f74a75801802f1463e451b22/pyinstaller-4.8.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
-  patches:
-    - 0001-depend-bindepend-find-statically-linked-libraries.patch
-    - 0002-Bootloader-build-Fallback-to-a-default-min-macOS-ver.patch
-    - 0003-hooks-Update-pkg_resources-hook-for-setuptools-v45.0.patch
 
 build:
   number: 0
@@ -28,10 +23,14 @@ build:
     - pyi-makespec = PyInstaller.utils.cliutils.makespec:run
     - pyi-set_version = PyInstaller.utils.cliutils.set_version:run
   script:
+    - export PYI_STATIC_ZLIB=1  # [unix]
     - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"               # [unix]
-    - export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${macos_min_version}"  # [osx]
     # Remove the pre-compiled bootloaders (available in sdist)
     - rm -fr ${SRC_DIR}/PyInstaller/bootloader/{Darwin,Linux,Windows}-{64,32}bit  # [unix]
+    # Remove vendored waflib dir
+    - rm -fr ${SRC_DIR}/bootloader/waflib   # [unix]
+    - rd /s /q %SRC_DIR%\bootloader\waflib  # [win]
+    # Build the bootloader
     - pushd bootloader
     - waf --prefix="${PREFIX}" --target-arch=64bit --clang distclean all  # [osx]
     - waf --prefix="${PREFIX}" --gcc --no-lsb distclean all     # [linux]
@@ -39,9 +38,6 @@ build:
     - popd
     - "{{ PYTHON }} -m pip install . --no-deps -vv"
   preserve_egg_dir: True
-  ignore_run_exports:  # [win]
-    - vc  # [win]
-    - vs2015_runtime  # [win]
 
 requirements:
   build:
@@ -50,7 +46,6 @@ requirements:
     - python
     - setuptools
     - m2-patch  # [win]
-    - m2-gcc-libs  # [win]
     - patch  # [not win]
 
   host:
@@ -59,29 +54,21 @@ requirements:
     - setuptools
     - wheel
     - waf
-    - zlib  # [not win]
+    - zlib
 
   run:
     - altgraph
     - python
-    - pefile >=2017.9.3  # [win]
-    - pycryptodome
+    - pefile >=2022.5.30  # [win]
     - pywin32  # [win]
     - pywin32-ctypes  # [win]
-    - dis3  # [py27]
     - macholib >=1.8
-    - setuptools
+    - setuptools    # due to pkg_resources import
     - importlib-metadata >=0.8  # [py<38]
 
 test:
-  requires:
-    # The test requires objdump which is part of the binutils package.
-    # Maybe add this as a test dependency on all platforms?
-    - binutils      [linux and aarch64]
-
   imports:
     - PyInstaller
-
   commands:
     - pyinstaller --help
     - pyi-archive_viewer --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,11 +82,13 @@ test:
     - multiprocessing_test.py
 
 about:
-  home: http://www.pyinstaller.org
+  home: https://pyinstaller.org
   license: GPL-2.0-or-later
   license_family: GPL
   license_file: COPYING.txt
   summary: PyInstaller bundles a Python application and all its dependencies into a single package.
+  dev_url: https://github.com/pyinstaller/pyinstaller
+  doc_url: https://pyinstaller.org
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,8 +2,8 @@
 # NOTE: the test step triggers antivirus stuff.  Let IT know that you're building a new pyinstaller release,
 #    and that they should watch for hello.exe triggering alerts.  Windows jobs in particular will fail with
 #    what looks like a permission error.
-{% set version = "5.6.2" %}
-{% set sha256 = "865025b6809d777bb0f66d8f8ab50cc97dc3dbe0ff09a1ef1f2fd646432714fc" %}
+{% set version = "5.7.0" %}
+{% set sha256 = "0e5953937d35f0b37543cc6915dacaf3239bcbdf3fd3ecbb7866645468a16775" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,7 +77,6 @@ test:
     # These are designed for Windows only.
     - pyi-grab_version --help     # [win]
     - pyi-set_version --help      # [win]
-
   files:
     - hello.py
     - multiprocessing_test.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,6 @@ requirements:
     - setuptools
     - wheel
     - waf
-    - zlib
 
   run:
     - altgraph

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
-{% set name = "PyInstaller" %}
+{% set name = "pyinstaller" %}
 # NOTE: the test step triggers antivirus stuff.  Let IT know that you're building a new pyinstaller release,
 #    and that they should watch for hello.exe triggering alerts.  Windows jobs in particular will fail with
 #    what looks like a permission error.
-{% set version = "5.6.2" %}
-{% set sha256 = "865025b6809d777bb0f66d8f8ab50cc97dc3dbe0ff09a1ef1f2fd646432714fc" %}
+{% set version = "5.7.0" %}
+{% set sha256 = "0e5953937d35f0b37543cc6915dacaf3239bcbdf3fd3ecbb7866645468a16775" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,6 +87,13 @@ about:
   license_family: GPL
   license_file: COPYING.txt
   summary: PyInstaller bundles a Python application and all its dependencies into a single package.
+  description: |
+      PyInstaller bundles a Python application and all its dependencies into a single package.
+      The user can run the packaged app without installing a Python interpreter or any modules.
+      PyInstaller reads a Python script written by you. It analyzes your code to discover every
+      other module and library your script needs in order to execute. Then it collects copies of
+      all those files -- including the active Python interpreter! -- and puts them with your script
+      in a single folder, or optionally in a single executable file.
   dev_url: https://github.com/pyinstaller/pyinstaller
   doc_url: https://pyinstaller.org
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,8 +2,8 @@
 # NOTE: the test step triggers antivirus stuff.  Let IT know that you're building a new pyinstaller release,
 #    and that they should watch for hello.exe triggering alerts.  Windows jobs in particular will fail with
 #    what looks like a permission error.
-{% set version = "5.7.0" %}
-{% set sha256 = "0e5953937d35f0b37543cc6915dacaf3239bcbdf3fd3ecbb7866645468a16775" %}
+{% set version = "5.6.2" %}
+{% set sha256 = "865025b6809d777bb0f66d8f8ab50cc97dc3dbe0ff09a1ef1f2fd646432714fc" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -95,3 +95,5 @@ extra:
     - hadim
     - nehaljwani
     - mingwandroid
+  skip-lints:
+    - uses_setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,6 +67,8 @@ requirements:
 test:
   imports:
     - PyInstaller
+  requires:
+    - pip
   files:
     - hello.py
     - multiprocessing_test.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,6 @@ test:
 
 about:
   home: http://www.pyinstaller.org
-  # https://github.com/pyinstaller/pyinstaller/blob/v3.6/COPYING.txt#L11
   license: GPL-2.0-or-later
   license_family: GPL
   license_file: COPYING.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,6 @@ requirements:
     - pip
     - python
     - setuptools
-    - m2-patch  # [win]
-    - patch  # [not win]
 
   host:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,7 +62,7 @@ requirements:
     - pywin32  # [win]
     - pywin32-ctypes  # [win]
     - macholib >=1.8  # [osx]
-    - setuptools >= 42.0.0  # due to pkg_resources import
+    - setuptools >=42.0.0  # due to pkg_resources import
     - importlib-metadata >=0.8  # [py<38]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,10 +58,11 @@ requirements:
     - altgraph
     - python
     - pefile >=2022.5.30  # [win]
+    - pyinstaller-hooks-contrib >=2021.4
     - pywin32  # [win]
     - pywin32-ctypes  # [win]
-    - macholib >=1.8
-    - setuptools    # due to pkg_resources import
+    - macholib >=1.8  # [osx]
+    - setuptools >= 42.0.0  # due to pkg_resources import
     - importlib-metadata >=0.8  # [py<38]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,14 +69,6 @@ requirements:
 test:
   imports:
     - PyInstaller
-  commands:
-    - pyinstaller --help
-    - pyi-archive_viewer --help
-    - pyi-bindepend --help
-    - pyi-makespec --help
-    # These are designed for Windows only.
-    - pyi-grab_version --help     # [win]
-    - pyi-set_version --help      # [win]
   files:
     - hello.py
     - multiprocessing_test.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ requirements:
 
   run:
     - altgraph
+    - binutils  # [aarch64]
     - python
     - pefile >=2022.5.30  # [win]
     - pyinstaller-hooks-contrib >=2021.4

--- a/recipe/multiprocessing_test.py
+++ b/recipe/multiprocessing_test.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
     import sys
     if sys.platform.startswith('win'):
         multiprocessing.freeze_support()
-    elif sys.platform.startswith('darwin') and (sys.version_info[:2] == (3,8) or sys.version_info[:2] == (3,9)):
+    elif sys.platform.startswith('darwin') and (sys.version_info[:2][0] == 3) and sys.version_info[:2][1] >= 8:
         # https://bugs.python.org/issue40106
         # https://bugs.python.org/issue33725
 

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,3 +1,10 @@
+pyinstaller --help
+pyi-archive_viewer --help
+pyi-bindepend --help
+pyi-makespec --help
+pyi-grab_version --help
+pyi-set_version --help
+
 pyinstaller -n hello hello.py
 dir dist\hello
 dist\hello\hello.exe

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -5,6 +5,8 @@ pyi-makespec --help
 pyi-grab_version --help
 pyi-set_version --help
 
+pip check
+
 pyinstaller -n hello hello.py
 dir dist\hello
 dist\hello\hello.exe

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -5,6 +5,8 @@ pyi-archive_viewer --help
 pyi-bindepend --help
 pyi-makespec --help
 
+pip check
+
 declare -a _RUN_DEBUG=()
 # If you need to figure out what's going on here:
 # _RUN_DEBUG+=('-d')

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+pyinstaller --help
+pyi-archive_viewer --help
+pyi-bindepend --help
+pyi-makespec --help
+
 declare -a _RUN_DEBUG=()
 # If you need to figure out what's going on here:
 # _RUN_DEBUG+=('-d')


### PR DESCRIPTION
pyinstaller --> [conda-standalone](https://github.com/AnacondaRecipes/conda-standalone-feedstock/pull/8)

Jira ticket: https://anaconda.atlassian.net/browse/PKG-598

`pyinstaller 5.7.0` does not build on `s390x`, so we will update only to 5.6.2 for now.

# Changes

* Update to v5.6.2
* Update dependencies
* Fix multiprocess test for macOS
* Update metadata

# Package information

* Home: https://pyinstaller.org/
* Upstream: https://github.com/pyinstaller/pyinstaller/
* Change log: https://pyinstaller.org/en/stable/CHANGES.html