### PR TITLE
Rebuild for py312 win

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-staging_channels:
+channels:
  - https://staging.continuum.io/prefect/fs/pefile-feedstock/pr3/70149e3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
- - https://staging.continuum.io/prefect/fs/pefile-feedstock/pr3/70149e3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+staging_channels:
+ - https://staging.continuum.io/prefect/fs/pefile-feedstock/pr3/70149e3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37 or osx]
+  # temporary skip to remedy py312 missing on win
+  skip: True  # [not (win and py==312)]
   entry_points:
     - pyinstaller = PyInstaller.__main__:run
     - pyi-archive_viewer = PyInstaller.utils.cliutils.archive_viewer:run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 0  # trigger
   skip: True  # [py<37]
   entry_points:
     - pyinstaller = PyInstaller.__main__:run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0  # trigger
-  skip: True  # [py<37]
+  number: 0
+  skip: True  # [py<37 or osx]
   entry_points:
     - pyinstaller = PyInstaller.__main__:run
     - pyi-archive_viewer = PyInstaller.utils.cliutils.archive_viewer:run


### PR DESCRIPTION
### Overview
Rebuild for pyinstaller-hooks-contrib for latest pyinstaller.

Dependency Chain:
`pefile` > `pyinstaller 5.13.2` (rebuild for win) > `pyinstaller-hooks-contrib` > `pyinstaller 6.7.0`

Related PRs:
[`pefile`](https://github.com/AnacondaRecipes/pefile-feedstock/pull/3)
[`pyinstaller` rebuild](https://github.com/AnacondaRecipes/pyinstaller-feedstock/pull/10)
[`pyinstaller-hooks-contrib`](https://github.com/AnacondaRecipes/pyinstaller-hooks-contrib-feedstock/pull/3)

Note:
- Temporarily skipping everything but `win` due to recent change in cbc causing rebuild of osx that is unnecessary in this PR. Immediately following PR will have the skip removed.
